### PR TITLE
Allow sharing an article before the web view has finished loading

### DIFF
--- a/SVWebViewController/SVWebViewController.m
+++ b/SVWebViewController/SVWebViewController.m
@@ -372,7 +372,7 @@
 }
 
 - (void)actionButtonTapped:(id)sender {
-    NSURL *url = self.webView.request.URL ? self.webView.request.URL : self.request.URL;
+    NSURL *url = self.webView.request.URL.absoluteString.length > 0 ? self.webView.request.URL : self.request.URL;
     if (url != nil) {
         NSArray *activities = @[[SVWebViewControllerActivitySafari new], [SVWebViewControllerActivityChrome new]];
         


### PR DESCRIPTION
Hey @bonzoq, nice work. 

Sometimes i'd like to share an article (e.g. save to Pocket) without having to wait for the web view to finish loading. Currently we're not able to do that, we're instead sharing an empty URL. This Pull Request fixes that.

By the way, i'm opening a couple issues regarding sharing from the story list screen and sharing comments, to know what you think of it.

Thanks