### PR TITLE
Define target for pods

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,8 +2,10 @@ platform :ios, '8.1'
 
 source 'https://github.com/CocoaPods/Specs.git'
 
-pod 'Colours'
-pod 'NJKWebViewProgress'
-pod 'Appirater'
-pod 'SWRevealViewController'
-pod 'MBProgressHUD', '~> 0.9.1'
+target "hn" do
+  pod 'Colours'
+  pod 'NJKWebViewProgress'
+  pod 'Appirater'
+  pod 'SWRevealViewController'
+  pod 'MBProgressHUD', '~> 0.9.1'
+end


### PR DESCRIPTION
Since version 1.0.0 of cocoapods, it is required to have a target for each pod. This change indeed resolves the following error:

```
[!] The dependency `Colours ` is not used in any concrete target.
```
